### PR TITLE
Let Fjall lock the database instead of manually

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,11 @@ mod flags;
 mod http;
 mod supervisor;
 
-use std::fs::{self, File};
+use std::fs;
 use std::path::Path;
 use std::process::exit;
 
 use anyhow::{Context, Result, bail};
-use fd_lock::RwLock;
 use ractor::Actor;
 use tokio::signal::unix::{SignalKind, signal};
 use tracing::{error, info};
@@ -57,23 +56,6 @@ async fn main() -> Result<()> {
     if !keyspace_name.exists() {
         create_keyspace_folder(&keyspace_name).context("Failed to create database folder")?;
     }
-    let lock_file =
-        File::create(keyspace_name.join("lock")).context("Failed to create lock file")?;
-    let mut keyspace_lock = RwLock::new(lock_file);
-    let write_guard = match keyspace_lock.try_write() {
-        Ok(guard) => guard,
-        Err(_) => {
-            eprintln!(
-                "Database '{}' cannot be accessed because it is locked by another process.",
-                keyspace_name.display()
-            );
-            eprintln!(
-                "If you are certain no other process is using this database, delete '{}' to remove the lock file.",
-                keyspace_name.join("lock").display()
-            );
-            exit(1);
-        }
-    };
 
     let database = fjall::Database::builder(&keyspace_name)
         .manual_journal_persist(true)
@@ -90,8 +72,6 @@ async fn main() -> Result<()> {
     match flags.subcommand {
         PinkaCmd::Serve(_) => serve(config).await?,
     }
-
-    drop(write_guard);
 
     Ok(())
 }


### PR DESCRIPTION
I ran into an issue where I could not start the database under any circumstances because of buggy lock file code that I don't really understand. This commit simply removes it. I have tested running the same daemon simultaneously against the same database and Fjall correctly exits with a lock error with this patch applied, and now I can successfully run the service.

Here is the error I was getting beforehand when running a single(!) Pinka daemon:

```
> RUST_BACKTRACE=1 target/debug/pinka serve --config /etc/pinka.toml
2026-03-26T04:26:04.413855Z  INFO fjall::db: Creating database at /var/lib/pinka/single
Error: Failed to open database

Caused by:
    FjallError: Locked

Stack backtrace:
   0: <E as anyhow::context::ext::StdError>::ext_context
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.102/src/backtrace.rs:10:14
   1: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::context
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.102/src/context.rs:54:37
   2: pinka::main::{{closure}}
             at ./src/main.rs:81:10
   3: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/future/future.rs:133:9
   4: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/park.rs:284:71
   5: tokio::task::coop::with_budget
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/task/coop/mod.rs:167:5
   6: tokio::task::coop::budget
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/task/coop/mod.rs:133:5
   7: tokio::runtime::park::CachedParkThread::block_on
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/park.rs:284:31
   8: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context/blocking.rs:66:14
   9: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/mod.rs:89:22
  10: tokio::runtime::context::runtime::enter_runtime
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context/runtime.rs:65:16
  11: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/mod.rs:88:9
  12: tokio::runtime::runtime::Runtime::block_on_inner
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/runtime.rs:373:50
  13: tokio::runtime::runtime::Runtime::block_on
             at /home/pinka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/runtime.rs:343:18
  14: pinka::main
             at ./src/main.rs:96:7
  15: core::ops::function::FnOnce::call_once
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/ops/function.rs:250:5
  16: std::sys::backtrace::__rust_begin_short_backtrace
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/sys/backtrace.rs:166:18
  17: std::rt::lang_start::{{closure}}
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/rt.rs:206:18
  18: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/ops/function.rs:287:21
  19: std::panicking::catch_unwind::do_call
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:581:40
  20: std::panicking::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:544:19
  21: std::panic::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panic.rs:359:14
  22: std::rt::lang_start_internal::{{closure}}
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/rt.rs:175:24
  23: std::panicking::catch_unwind::do_call
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:581:40
  24: std::panicking::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:544:19
  25: std::panic::catch_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panic.rs:359:14
  26: std::rt::lang_start_internal
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/rt.rs:171:5
  27: std::rt::lang_start
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/rt.rs:205:5
  28: main
  29: __libc_start_call_main
             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  30: __libc_start_main_impl
             at ./csu/../csu/libc-start.c:360:3
  31: _start
```

Here is the error now after attempting to run a second Pinka daemon simultaneously:

```
2026-03-26T04:49:05.824656Z  INFO fjall::db: Recovering database at /var/lib/pinka/single
Error: Failed to open database

Caused by:
    FjallError: Locked
```