### PR TITLE
Correct the content type for the javascript asset

### DIFF
--- a/src/http/assets.rs
+++ b/src/http/assets.rs
@@ -1,3 +1,10 @@
-pub(super) async fn get_comments_js() -> &'static str {
-    include_str!("comments.js")
+use axum::{
+    response::IntoResponse,
+    http::{HeaderMap, header},
+};
+
+pub(super) async fn get_comments_js() -> impl IntoResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, "text/javascript".parse().unwrap());
+    (headers, include_str!("comments.js"))
 }


### PR DESCRIPTION
Firefox was warning me that the Content-Type for comments.js was text/plain and not text/javascript. This fixes that.